### PR TITLE
fix(user-location): handle case where new user has location set

### DIFF
--- a/src/PockyBot.NET.Tests/Services/Triggers/PegTests.cs
+++ b/src/PockyBot.NET.Tests/Services/Triggers/PegTests.cs
@@ -81,7 +81,7 @@ namespace PockyBot.NET.Tests.Services.Triggers
 
         private void GivenAUser(PockyUser user)
         {
-            _pockyUserRepository.AddOrUpdateUser(user.UserId, Arg.Any<string>()).Returns(user);
+            _pockyUserRepository.AddOrUpdateUser(user.UserId, Arg.Any<string>()).Returns(Task.FromResult(user));
         }
 
         private void GivenAStringConfig(string configName, List<string> config)

--- a/src/PockyBot.NET.Tests/Services/UserLocationSetterTests.cs
+++ b/src/PockyBot.NET.Tests/Services/UserLocationSetterTests.cs
@@ -1,4 +1,5 @@
 using System.Threading.Tasks;
+using GlobalX.ChatBots.Core;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Shouldly;
 using TestStack.BDDfy;
@@ -16,6 +17,7 @@ namespace PockyBot.NET.Tests.Services
         private readonly IPockyUserRepository _pockyUserRepository;
         private readonly ILocationRepository _locationRepository;
         private readonly IUserLocationRepository _userLocationRepository;
+        private readonly IChatHelper _chatHelper;
 
         private string[] _commands;
         private string[] _mentionedUsers;
@@ -35,7 +37,8 @@ namespace PockyBot.NET.Tests.Services
 
             _locationRepository = Substitute.For<ILocationRepository>();
             _userLocationRepository = Substitute.For<IUserLocationRepository>();
-            _subject = new UserLocationSetter(_pockyUserRepository, _locationRepository, _userLocationRepository);
+            _chatHelper = Substitute.For<IChatHelper>();
+            _subject = new UserLocationSetter(_pockyUserRepository, _locationRepository, _userLocationRepository, _chatHelper);
         }
 
         [Theory]

--- a/src/PockyBot.NET/Persistence/Repositories/IPockyUserRepository.cs
+++ b/src/PockyBot.NET/Persistence/Repositories/IPockyUserRepository.cs
@@ -8,7 +8,7 @@ namespace PockyBot.NET.Persistence.Repositories
     {
         PockyUser GetUser(string userId);
         List<PockyUser> GetUsersByUsername(string username);
-        PockyUser AddOrUpdateUser(string userId, string username);
+        Task<PockyUser> AddOrUpdateUser(string userId, string username);
         List<PockyUser> GetAllUsersWithPegs();
         List<PockyUser> GetAllUsersLocations();
         Task RemoveUser(PockyUser user);

--- a/src/PockyBot.NET/Persistence/Repositories/PockyUserRepository.cs
+++ b/src/PockyBot.NET/Persistence/Repositories/PockyUserRepository.cs
@@ -39,7 +39,7 @@ namespace PockyBot.NET.Persistence.Repositories
                 .ToList();
         }
 
-        public PockyUser AddOrUpdateUser(string userId, string username)
+        public async Task<PockyUser> AddOrUpdateUser(string userId, string username)
         {
             var existingUser = _context.PockyUsers
                 .Include(x => x.PegsGiven)
@@ -49,7 +49,7 @@ namespace PockyBot.NET.Persistence.Repositories
             if (existingUser != null)
             {
                 existingUser.Username = username;
-                _context.SaveChanges();
+                await _context.SaveChangesAsync();
                 return existingUser;
             }
 
@@ -59,7 +59,7 @@ namespace PockyBot.NET.Persistence.Repositories
                 Username = username
             };
             _context.Add(newPockyUser);
-            _context.SaveChanges();
+            await _context.SaveChangesAsync();
 
             return newPockyUser;
         }

--- a/src/PockyBot.NET/Persistence/Repositories/UserLocationRepository.cs
+++ b/src/PockyBot.NET/Persistence/Repositories/UserLocationRepository.cs
@@ -27,7 +27,7 @@ namespace PockyBot.NET.Persistence.Repositories
         public async Task UpsertUserLocation(PockyUser user, string location)
         {
             var userLocation = await _context.UserLocations.FirstOrDefaultAsync(x =>
-                x.UserId == (user != null ? user.UserId : null));
+                x.UserId == user.UserId);
 
             if (userLocation == null)
             {

--- a/src/PockyBot.NET/PockyBotFactory.cs
+++ b/src/PockyBot.NET/PockyBotFactory.cs
@@ -31,7 +31,7 @@ namespace PockyBot.NET
             var pegResultsHelper = new PegResultsHelper(configRepository, pegHelper);
             var userLocationGetter = new UserLocationGetter(pockyUserRepository);
             var userLocationSetter =
-                new UserLocationSetter(pockyUserRepository, locationRepository, userLocationRepository);
+                new UserLocationSetter(pockyUserRepository, locationRepository, userLocationRepository, chatHelper);
             var userLocationDeleter = new UserLocationDeleter(userLocationRepository);
 
             var triggers = new List<ITrigger>

--- a/src/PockyBot.NET/Services/Triggers/Peg.cs
+++ b/src/PockyBot.NET/Services/Triggers/Peg.cs
@@ -60,7 +60,7 @@ namespace PockyBot.NET.Services.Triggers
 
             _logger.LogDebug("Getting user information for id {userid}, username {username}", message.Sender.UserId,
                 message.Sender.Username);
-            var sender = _pockyUserRepository.AddOrUpdateUser(message.Sender.UserId, message.Sender.Username);
+            var sender = await _pockyUserRepository.AddOrUpdateUser(message.Sender.UserId, message.Sender.Username);
             var comment = string.Join(string.Empty, message.MessageParts.Skip(3).Select(x => x.Text)).Trim();
 
             var requireKeywords = _configRepository.GetGeneralConfig("requireValues");
@@ -83,7 +83,7 @@ namespace PockyBot.NET.Services.Triggers
 
             var receiverId = message.MessageParts[2].UserId;
             var receiver = await _chatHelper.People.GetPersonAsync(receiverId).ConfigureAwait(false);
-            var dbReceiver = _pockyUserRepository.AddOrUpdateUser(receiver.UserId, receiver.Username);
+            var dbReceiver = await _pockyUserRepository.AddOrUpdateUser(receiver.UserId, receiver.Username);
 
             _logger.LogInformation(
                 "Giving peg with sender {senderId}, receiver {receiverId}, validity {isPegValid}, comment {comment}",

--- a/src/PockyBot.NET/Services/Triggers/UserLocation.cs
+++ b/src/PockyBot.NET/Services/Triggers/UserLocation.cs
@@ -2,7 +2,9 @@ using System;
 using System.Linq;
 using System.Threading.Tasks;
 using GlobalX.ChatBots.Core.Messages;
+using GlobalX.ChatBots.Core.People;
 using PockyBot.NET.Constants;
+using PockyBot.NET.Persistence.Models;
 using PockyBot.NET.Persistence.Repositories;
 
 namespace PockyBot.NET.Services.Triggers
@@ -30,6 +32,7 @@ namespace PockyBot.NET.Services.Triggers
 
         public async Task<Message> Respond(Message message)
         {
+            var createUser = CreateUser(message.Sender);
             var fullText = message.MessageParts.Skip(1).Select(x => x.Text);
 
             var mentionedUsers = message.MessageParts.Skip(1)
@@ -52,6 +55,8 @@ namespace PockyBot.NET.Services.Triggers
             var command = commands[1];
             commands = commands.Skip(2).ToArray();
 
+            await createUser;
+
             return new Message
             {
                 Text = command.ToLowerInvariant() switch
@@ -63,6 +68,11 @@ namespace PockyBot.NET.Services.Triggers
                     _ => "Unknown command. Possible values are get, set, and delete."
                 }
             };
+        }
+
+        private async Task CreateUser(Person user)
+        {
+            await _pockyUserRepository.AddOrUpdateUser(user.UserId, user.Username);
         }
 
         private bool UserIsAdmin(string userId)


### PR DESCRIPTION
Correctly handle the case where a user that has not interacted with PockyBot yet has their location set, or sets the location of another.