### PR TITLE
fix: typo in welcome message fixed from ouy to out

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ pockybot.Respond(message);
 
 ## Database
 
-PockyBot requires a postgres database. THe `database` folder in this
+PockyBot requires a postgres database. The `database` folder in this
 repository contains a number of `.sql` files you can use to set this up.
 
 Table `generalconfig` is initalised with default values as follows:

--- a/src/PockyBot.NET/Services/Triggers/Welcome.cs
+++ b/src/PockyBot.NET/Services/Triggers/Welcome.cs
@@ -29,7 +29,7 @@ namespace PockyBot.NET.Services.Triggers
         {
             var newMessage = "## Hello world!\n" +
                              $"I'm {_pockyBotSettings.BotName}. I help you spread the word about the great work that your team mates are doing! " +
-                             "I hand ouy pegs to everyone you tell me about. ";
+                             "I hand out pegs to everyone you tell me about. ";
 
             var keywordsRequired = _configRepository.GetGeneralConfig("requireValues") == 1;
             if (keywordsRequired)


### PR DESCRIPTION
Fixed Welcome.cs message's typo "ouy" on line 32 to be the correct "out" as expected.
Fixed README.md typo where "The" had an incorrect capitalisation on line 151