### PR TITLE
Update peg check order

### DIFF
--- a/src/PockyBot.NET.Tests/Services/Pegs/PegHelperTests.cs
+++ b/src/PockyBot.NET.Tests/Services/Pegs/PegHelperTests.cs
@@ -120,7 +120,7 @@ namespace PockyBot.NET.Tests.Services.Pegs
 
         private void WhenIsPenaltyPegIsCalled()
         {
-            _isPegValid = _subject.IsPenaltyPeg(_comment, _requireKeywords, _penaltyKeywords, _keywords);
+            _isPegValid = _subject.IsPenaltyPeg(_comment, _penaltyKeywords, _keywords);
         }
 
         private void WhenGettingAPegWeighting()

--- a/src/PockyBot.NET.Tests/Services/Pegs/PegRequestValidatorTests.cs
+++ b/src/PockyBot.NET.Tests/Services/Pegs/PegRequestValidatorTests.cs
@@ -58,6 +58,28 @@ namespace PockyBot.NET.Tests.Services.Pegs
                 .BDDfy();
         }
 
+        [Theory]
+        [MemberData(nameof(PegRequestValidatorTestData.ValidFormatTestData), MemberType = typeof(PegRequestValidatorTestData))]
+        public void TestValidateValidPegRequestFormat(Message message)
+        {
+            this.Given(x => GivenAMessage(message))
+                .When(x => WhenValidatingAPegRequestsFormat())
+                .Then(x => ThenTheMessageShouldBeValid())
+                .BDDfy();
+        }
+
+        [Theory]
+        [MemberData(nameof(PegRequestValidatorTestData.InvalidFormatTestData), MemberType = typeof(PegRequestValidatorTestData))]
+        public void TestValidateInvalidPegRequestFormat(PockyBotSettings settings, Message message, string errorMessage)
+        {
+            this.Given(x => GivenPockyBotSettings(settings))
+                .And(x => GivenAMessage(message))
+                .When(x => WhenValidatingAPegRequestsFormat())
+                .Then(x =>ThenTheMessageShouldBeInvalid())
+                .And(x => ThenTheErrorMessageShouldBe(errorMessage))
+                .BDDfy();
+        }
+
         private void GivenPockyBotSettings(PockyBotSettings settings)
         {
             _settings.BotId = settings.BotId;
@@ -82,6 +104,11 @@ namespace PockyBot.NET.Tests.Services.Pegs
         private void WhenValidatingAPegRequest()
         {
             _exception = Record.Exception(() => _subject.ValidatePegRequest(_message));
+        }
+
+        private void WhenValidatingAPegRequestsFormat()
+        {
+            _exception = Record.Exception(() => _subject.ValidatePegRequestFormat(_message));
         }
 
         private void ThenTheMessageShouldBeValid()

--- a/src/PockyBot.NET.Tests/Services/Pegs/PegResultsHelperTests.cs
+++ b/src/PockyBot.NET.Tests/Services/Pegs/PegResultsHelperTests.cs
@@ -95,7 +95,7 @@ namespace PockyBot.NET.Tests.Services.Pegs
 
         private void GivenPenaltyPeg(string penaltyKeyword)
         {
-            _pegHelper.IsPenaltyPeg(Arg.Any<string>(), Arg.Any<int?>(), Arg.Any<string[]>(), Arg.Any<string[]>()).Returns(
+            _pegHelper.IsPenaltyPeg(Arg.Any<string>(),  Arg.Any<string[]>(), Arg.Any<string[]>()).Returns(
                 x => ((string)x[0]).Contains(penaltyKeyword));
         }
 

--- a/src/PockyBot.NET.Tests/TestData/Pegs/PegRequestValidatorTestData.cs
+++ b/src/PockyBot.NET.Tests/TestData/Pegs/PegRequestValidatorTestData.cs
@@ -332,17 +332,104 @@ namespace PockyBot.NET.Tests.TestData.Pegs
             };
         }
 
-        public static IEnumerable<object[]> InvalidTestData()
+        public static IEnumerable<object[]> ValidFormatTestData()
+        {
+            yield return new object[]
+            {
+                new Message
+                {
+                    Text = "TestBot peg Test User 2 for doing some keyword2 things",
+                    MessageParts = new[]
+                    {
+                        new MessagePart
+                        {
+                            Text = "TestBot",
+                            MessageType = MessageType.PersonMention,
+                            UserId = "testBotId"
+                        },
+                        new MessagePart
+                        {
+                            Text = " peg ",
+                            MessageType = MessageType.Text
+                        },
+                        new MessagePart
+                        {
+                            Text = "Test User 2",
+                            MessageType = MessageType.PersonMention,
+                            UserId = "testUser2Id"
+                        },
+                        new MessagePart
+                        {
+                            Text = " for doing some keyword2 things",
+                            MessageType = MessageType.Text
+                        }
+                    },
+                    Sender = new Person
+                    {
+                        UserId = "testUserId",
+                        Username = "Test User",
+                        Type = PersonType.Person
+                    }
+                }
+            };
+
+            // extra mentions in text
+            yield return new object[]
+            {
+                new Message
+                {
+                    Text = "TestBot peg Test User 2 for doing some keyword2 things",
+                    MessageParts = new[]
+                    {
+                        new MessagePart
+                        {
+                            Text = "TestBot",
+                            MessageType = MessageType.PersonMention,
+                            UserId = "testBotId"
+                        },
+                        new MessagePart
+                        {
+                            Text = " peg ",
+                            MessageType = MessageType.Text
+                        },
+                        new MessagePart
+                        {
+                            Text = "Test User 2",
+                            MessageType = MessageType.PersonMention,
+                            UserId = "testUser2Id"
+                        },
+                        new MessagePart
+                        {
+                            Text = " for doing some keyword2 things with ",
+                            MessageType = MessageType.Text
+                        },
+                        new MessagePart
+                        {
+                            Text = "User3",
+                            MessageType = MessageType.PersonMention
+                        },
+                        new MessagePart
+                        {
+                            Text = " and I to fix things",
+                            MessageType = MessageType.Text
+                        }
+                    },
+                    Sender = new Person
+                    {
+                        UserId = "testUserId",
+                        Username = "Test User",
+                        Type = PersonType.Person
+                    }
+                }
+            };
+        }
+
+        public static IEnumerable<object[]> InvalidFormatTestData()
         {
             // not enough parts
             yield return new object[]
             {
                 GetBasicSettings(),
-                1, // commentsRequired
-                new List<string> { "keyword1", "keyword2", "keyword3" },
-                new List<string> { "penaltyKeyword" },
-                new List<string>(),
-                1, // requireValues
                 new Message
                 {
                     Text = "TestBot peg ",
@@ -374,11 +461,6 @@ namespace PockyBot.NET.Tests.TestData.Pegs
             yield return new object[]
             {
                 GetBasicSettings(),
-                1, // commentsRequired
-                new List<string> { "keyword1", "keyword2", "keyword3" },
-                new List<string> { "penaltyKeyword" },
-                new List<string>(),
-                1, // requireValues
                 new Message
                 {
                     Text = "TestBot peg Test User 2 for doing some keyword2 things",
@@ -422,11 +504,6 @@ namespace PockyBot.NET.Tests.TestData.Pegs
             yield return new object[]
             {
                 GetBasicSettings(),
-                1, // commentsRequired
-                new List<string> { "keyword1", "keyword2", "keyword3" },
-                new List<string> { "penaltyKeyword" },
-                new List<string>(),
-                1, // requireValues
                 new Message
                 {
                     Text = "TestBot pegg Test User 2 for doing some keyword2 things",
@@ -469,11 +546,6 @@ namespace PockyBot.NET.Tests.TestData.Pegs
             yield return new object[]
             {
                 GetBasicSettings(),
-                1, // commentsRequired
-                new List<string> { "keyword1", "keyword2", "keyword3" },
-                new List<string> { "penaltyKeyword" },
-                new List<string>(),
-                1, // requireValues
                 new Message
                 {
                     Text = "TestBot peg Test User 2 for doing some keyword2 things",
@@ -511,7 +583,10 @@ namespace PockyBot.NET.Tests.TestData.Pegs
                 },
                 "I'm sorry, I couldn't understand your peg request. Please use the following format: `@TestBot peg @Person this is the reason for giving you a peg`."
             };
+        }
 
+        public static IEnumerable<object[]> InvalidTestData()
+        {
             // comment required, not provided
             yield return new object[]
             {

--- a/src/PockyBot.NET.Tests/TestData/Triggers/PegTestData.cs
+++ b/src/PockyBot.NET.Tests/TestData/Triggers/PegTestData.cs
@@ -62,7 +62,7 @@ namespace PockyBot.NET.Tests.TestData.Triggers
                 },
                 5, // limit
                 "for reasons", // comment
-                true, // is peg valid
+                false, // is penalty peg
                 new Person // receiver
                 {
                     UserId = "testUser1Id",
@@ -133,7 +133,7 @@ namespace PockyBot.NET.Tests.TestData.Triggers
                 },
                 1, // limit
                 "for reasons", // comment
-                true, // is peg valid
+                false, // is penalty peg
                 new Person // receiver
                 {
                     UserId = "testUser1Id",
@@ -199,7 +199,7 @@ namespace PockyBot.NET.Tests.TestData.Triggers
                 },
                 1, // limit
                 "for shameful reasons", // comment
-                false, // is peg valid
+                true, // is penalty peg
                 new Person // receiver
                 {
                     UserId = "testUser1Id",
@@ -265,7 +265,7 @@ namespace PockyBot.NET.Tests.TestData.Triggers
                 },
                 1, // limit
                 "for shameful reasons", // comment
-                false, // is peg valid
+                true, // is penalty peg
                 new Person // receiver
                 {
                     UserId = "testUser1Id",
@@ -334,7 +334,7 @@ namespace PockyBot.NET.Tests.TestData.Triggers
                 },
                 1, // limit
                 "for reasons", // comment
-                true, // is peg valid
+                false, // is penalty peg
                 new Person // receiver
                 {
                     UserId = "testUser1Id",

--- a/src/PockyBot.NET/Services/Pegs/IPegHelper.cs
+++ b/src/PockyBot.NET/Services/Pegs/IPegHelper.cs
@@ -3,7 +3,7 @@ namespace PockyBot.NET.Services.Pegs
     internal interface IPegHelper
     {
         bool IsPegValid(string comment, int? requireKeywords, string[] keywords, string[] penaltyKeywords);
-        bool IsPenaltyPeg(string comment, int? requireKeywords, string[] penaltyKeywords, string[] validKeywords);
+        bool IsPenaltyPeg(string comment, string[] penaltyKeywords, string[] validKeywords);
         int GetPegWeighting(string senderLocation, string receiverLocation);
     }
 }

--- a/src/PockyBot.NET/Services/Pegs/IPegRequestValidator.cs
+++ b/src/PockyBot.NET/Services/Pegs/IPegRequestValidator.cs
@@ -5,5 +5,6 @@ namespace PockyBot.NET.Services.Pegs
     internal interface IPegRequestValidator
     {
         void ValidatePegRequest(Message message);
+        void ValidatePegRequestFormat(Message message);
     }
 }

--- a/src/PockyBot.NET/Services/Pegs/PegHelper.cs
+++ b/src/PockyBot.NET/Services/Pegs/PegHelper.cs
@@ -46,9 +46,10 @@ namespace PockyBot.NET.Services.Pegs
             return _configRepository.GetGeneralConfig("remoteLocationWeightingDefault") ?? DefaultRemoteLocationWeighting;
         }
 
-        public bool IsPenaltyPeg(string comment, int? requireKeywords, string[] penaltyKeywords, string[] validKeywords)
+        public bool IsPenaltyPeg(string comment, string[] penaltyKeywords, string[] validKeywords)
         {
-            return penaltyKeywords.Any(x => comment.IndexOf(x, StringComparison.OrdinalIgnoreCase) >= 0) && !validKeywords.Any(x => comment.IndexOf(x, StringComparison.OrdinalIgnoreCase) >= 0);
+            return penaltyKeywords.Any(x => comment.IndexOf(x, StringComparison.OrdinalIgnoreCase) >= 0) &&
+                   !validKeywords.Any(x => comment.IndexOf(x, StringComparison.OrdinalIgnoreCase) >= 0);
         }
     }
 }

--- a/src/PockyBot.NET/Services/Pegs/PegRequestValidator.cs
+++ b/src/PockyBot.NET/Services/Pegs/PegRequestValidator.cs
@@ -23,13 +23,16 @@ namespace PockyBot.NET.Services.Pegs
 
         public void ValidatePegRequest(Message message)
         {
-            ValidateMessageFormat(message);
-
             ValidateRecipient(message);
             var comment = GetCommentText(message);
             ValidateComment(comment);
 
             ValidateKeywords(comment);
+        }
+
+        public void ValidatePegRequestFormat(Message message)
+        {
+            ValidateMessageFormat(message);
         }
 
         private void ValidateMessageFormat(Message message)

--- a/src/PockyBot.NET/Services/Pegs/PegResultsHelper.cs
+++ b/src/PockyBot.NET/Services/Pegs/PegResultsHelper.cs
@@ -30,7 +30,7 @@ namespace PockyBot.NET.Services.Pegs
                 var receiverLocation = x.Location?.Location;
                 var validPegs = GetValidPegs(x.PegsReceived, requireKeywords, keywords, penaltyKeywords,
                     linkedKeywords, receiverLocation);
-                var penaltyPegs = GetPenaltyPegs(x.PegsGiven, requireKeywords, keywords.Concat(linkedKeywords.Select(x =>  x.Keyword)).ToArray(), penaltyKeywords);
+                var penaltyPegs = GetPenaltyPegs(x.PegsGiven, keywords.Concat(linkedKeywords.Select(k =>  k.Keyword)).ToArray(), penaltyKeywords);
 
                 return new PegRecipient
                 {
@@ -105,10 +105,9 @@ namespace PockyBot.NET.Services.Pegs
                 .ToList();
         }
 
-        private List<PegDetails> GetPenaltyPegs(List<Peg> pegs, int? requireKeywords, string[] keywords,
-            string[] penaltyKeywords)
+        private List<PegDetails> GetPenaltyPegs(List<Peg> pegs, string[] keywords, string[] penaltyKeywords)
         {
-            return pegs.Where(y => _pegHelper.IsPenaltyPeg(y.Comment, requireKeywords, penaltyKeywords, keywords))
+            return pegs.Where(y => _pegHelper.IsPenaltyPeg(y.Comment, penaltyKeywords, keywords))
                 .Select(y => new PegDetails
                 {
                     SenderName = y.Receiver.Username,

--- a/src/PockyBot.NET/Services/Triggers/Status.cs
+++ b/src/PockyBot.NET/Services/Triggers/Status.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using GlobalX.ChatBots.Core.Messages;
 using Microsoft.Extensions.Logging;
 using PockyBot.NET.Constants;
+using PockyBot.NET.Models;
 using PockyBot.NET.Persistence.Models;
 using PockyBot.NET.Persistence.Repositories;
 using PockyBot.NET.Services.Pegs;
@@ -72,6 +73,8 @@ namespace PockyBot.NET.Services.Triggers
         {
             var requireKeywords = _configRepository.GetGeneralConfig("requireValues");
             var keywords = _configRepository.GetStringConfig("keyword").ToArray();
+            var linkedKeywords = _configRepository.GetStringConfig("linkedKeyword").Select(x => new LinkedKeyword(x));
+            keywords = keywords.Concat(linkedKeywords.Select(x => x.LinkedWord)).ToArray();
             var penaltyKeywords = _configRepository.GetStringConfig("penaltyKeyword").ToArray();
 
             var groupedPegs = pockyUser.PegsGiven.GroupBy(x =>


### PR DESCRIPTION
Fixes #26 

Also has the fix to the status trigger not categorising penalty pegs correctly.

The new peg check order is:
1. Message format
2. Pegs remaining
3. Recipient is not self
4. Comment is present if required
5. Keywords

A fair bit of refactoring went into this one too.